### PR TITLE
spec: requires dovecot-devel >= 2.2.36

### DIFF
--- a/dovecot-deleted-to-trash.spec
+++ b/dovecot-deleted-to-trash.spec
@@ -9,7 +9,7 @@ Source: %{name}-%{version}.tar.gz
 License: GPL
 
 BuildRequires: dovecot-devel
-Requires: dovecot >= 2.2.10
+Requires: dovecot >= 2.2.36
 
 %description 
 The purpose of this deleted_to_trash-plugin is that IMAP client,such


### PR DESCRIPTION
Fix error:
>Error: Couldn't load required plugin /usr/lib64/dovecot/lib89_deleted_to_trash_plugin.so:
>Module is for different ABI version 2.2.ABIv10(2.2.10) (we have 2.2.ABIv36(2.2.36))

NethServer/dev#5646